### PR TITLE
Add callout with details about the random field length

### DIFF
--- a/pages/docs/contributing/adding-a-new-app.mdx
+++ b/pages/docs/contributing/adding-a-new-app.mdx
@@ -159,6 +159,10 @@ You can choose between different types of fields. The app will automatically val
 You can also define a min and max length of input with the corresponding properties.
 The `env_variable` property is the name of the variable you'll use in your `docker-compose.yml` file. Be sure to have a unique name.
 
+<Callout type="info">
+  When using the field type random for a password or secret, the min value will be used to determine the length of the string. If the min value is omitted the default length is 32 characters.
+</Callout>
+
 So if we take the Nextcloud example again, this is how you would use the `form_fields` inside your compose file.
 
 ```yml


### PR DESCRIPTION
Info callout in adding a new app page with details about the random field lengths when using for passwords or secrets.